### PR TITLE
Update code in writing_functions lesson

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ some inspiration.
 
 **Comments, ideas, feedback**: Hao Ye, Philipp Bayer, Tim Head, Ethan White
 
-**Lesson contents**: Timothée Poisot
+**Lesson contents**: Timothée Poisot, [Zaki Ahmed](https://github.com/notzaki)
 
 **Other contributions**: Konrad Hinsen
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -162,7 +162,7 @@ some inspiration.
 
 ## Contributors
 
-**Lesson contents**: Timothée Poisot
+**Lesson contents**: Timothée Poisot, [Zaki Ahmed](https://github.com/notzaki)
 
 **Comments, ideas, feedback**: Hao Ye, Philipp Bayer, Tim Head, Ethan White, Andrew MacDonald
 

--- a/content/lessons/writing_functions.Jmd
+++ b/content/lessons/writing_functions.Jmd
@@ -337,7 +337,7 @@ So, how good is our estimate?
 
 ```julia
 estimate = estimate_pi(100000)
-println("Estimate: $(estimate)\tπ: $(π)")
+println("Estimate: $(estimate)\t\tπ: $(π+0)")
 ```
 
 ## Keyword arguments and default values

--- a/content/lessons/writing_functions.Jmd
+++ b/content/lessons/writing_functions.Jmd
@@ -151,7 +151,7 @@ function throw_darts(n::Int64)
     Also specifying the type of the objects will let the computer
     reserve exactly enough space in memory.
     =#
-    darts = Array{Tuple{Float64,Float64},1}(n)
+    darts = Array{Tuple{Float64,Float64},1}(undef,n)
 
     #=
     Now we can fill the variable with random darts. Julia has
@@ -170,7 +170,7 @@ function throw_darts(n::Int64)
         x, y = rand(2).*2
         darts[i] = (x, y)
         =#
-        darts[i] = rand(2).*2.0
+        darts[i] = Tuple(rand(2).*2.0)
     end
 
     #=

--- a/content/lessons/writing_functions.Jmd
+++ b/content/lessons/writing_functions.Jmd
@@ -379,7 +379,7 @@ then the computer will see that we have not asked for a specific value of `b`,
 and use the default. But if we use the following syntax,
 
 ```julia
-my_log_function(2.0; b=e)
+my_log_function(2.0; b=ℯ)
 ```
 
 then the value of `b` will be fixed (to $e$), and the function will use this.

--- a/content/lessons/writing_functions.md
+++ b/content/lessons/writing_functions.md
@@ -170,7 +170,7 @@ function throw_darts(n::Int64)
     Also specifying the type of the objects will let the computer
     reserve exactly enough space in memory.
     =#
-    darts = Array{Tuple{Float64,Float64},1}(n)
+    darts = Array{Tuple{Float64,Float64},1}(undef,n)
 
     #=
     Now we can fill the variable with random darts. Julia has
@@ -189,7 +189,7 @@ function throw_darts(n::Int64)
         x, y = rand(2).*2
         darts[i] = (x, y)
         =#
-        darts[i] = rand(2).*2.0
+        darts[i] = Tuple(rand(2).*2.0)
     end
 
     #=
@@ -421,27 +421,14 @@ So, how good is our estimate?
 
 ````julia
 estimate = estimate_pi(100000)
+println("Estimate: $(estimate)\t\tπ: $(π+0)")
 ````
 
 
-<pre class="julia-error">
-ERROR: MethodError: no method matching Array&#123;Tuple&#123;Float64,Float64&#125;,1&#125;&#40;::Int64&#41;
-Closest candidates are:
-  Array&#123;Tuple&#123;Float64,Float64&#125;,1&#125;&#40;&#41; where T at boot.jl:421
-  Array&#123;Tuple&#123;Float64,Float64&#125;,1&#125;&#40;&#33;Matched::UndefInitializer, &#33;Matched::Int64&#41; where T at boot.jl:402
-  Array&#123;Tuple&#123;Float64,Float64&#125;,1&#125;&#40;&#33;Matched::UndefInitializer, &#33;Matched::Int64...&#41; where &#123;T, N&#125; at boot.jl:408
-  ...
-</pre>
-
-
-````julia
-println("Estimate: $(estimate)\tπ: $(π)")
+````
+Estimate: 3.14284		π: 3.141592653589793
 ````
 
-
-<pre class="julia-error">
-ERROR: UndefVarError: estimate not defined
-</pre>
 
 
 
@@ -503,13 +490,14 @@ then the computer will see that we have not asked for a specific value of `b`,
 and use the default. But if we use the following syntax,
 
 ````julia
-my_log_function(2.0; b=e)
+my_log_function(2.0; b=ℯ)
 ````
 
 
-<pre class="julia-error">
-ERROR: UndefVarError: e not defined
-</pre>
+````
+0.6931471805599453
+````
+
 
 
 
@@ -581,7 +569,7 @@ println("It takes $(round(time_int_and_float/time_float_and_float; digits=2)) ti
 
 
 ````
-It takes 1.47 times longer to work with different types!
+It takes 1.13 times longer to work with different types!
 ````
 
 


### PR DESCRIPTION
The [lesson on writing functions](http://sciencecomputing.io/lessons/writing_functions/) has `ERROR` as the output in two instances. This PR tries to fix that.

The first case was when `estimate_pi()` is called and this was resolved by updating the `throw_darts()` function by:

- adding `undef` when initializing the array-of-tuples
    + would it be simpler to use an Nx2 array? Then it could be initialized using `zeros()` without needing to explicitly define the types. Although this would also require updating the other functions accordingly. 
- wrapping a `Tuple()` around `rand()`
    + The (older?) commented code in the loop also worked, although I wasn't able to understand what the "unpack" part of the comment was referring to. I'm guessing there's a simpler way of converting the two rands into a tuple that I'm missing? 
- somewhat related: `println(π)` just returns `π`. Not terribly exciting. I managed to print the actual value by doing `println(π+0)`. There is probably a more elegant way to accomplish this that I'm unaware of. 

The second case was when `my_log_function(2.0; b=e)` is called. This was resolved by replacing `e` with---I don't know what to call it---a fancier e? (inserted by typing `\euler`).

