### PR TITLE
Add CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,15 @@
+# This CITATION.cff file was generated with cffinit.
+# Visit https://bit.ly/cffinit to generate yours today!
+
+cff-version: 1.2.0
+title: Scientific Computing (for the rest of us)
+message: >-
+  If you use this material, please cite it using the
+  metadata from this file.
+type: software
+authors:
+  - given-names: Timothée
+    family-names: Poisot
+    email: timothee.poisot@umontreal.ca
+    affiliation: Université de Montréal
+    orcid: 'https://orcid.org/0000-0002-0735-5184'


### PR DESCRIPTION
This adds a `CITATION.cff` file at the root, which will allow Zotero integration

- closes #61 
- closes #62 